### PR TITLE
feat: changeable bin

### DIFF
--- a/.changeset/moody-radios-rule.md
+++ b/.changeset/moody-radios-rule.md
@@ -1,0 +1,5 @@
+---
+"cloudflared": patch
+---
+
+Make `bin` respect `process.env.CLOUDFLARED_BIN` before choosing the default path, and it can be changed later using `use`.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,26 @@
 import path from "node:path";
 
-/**
- * The path to the cloudflared binary.
- */
-export const bin = path.join(
+export const DEFAULT_CLOUDFLARED_BIN = path.join(
     __dirname,
     "..",
     "bin",
     process.platform === "win32" ? "cloudflared.exe" : "cloudflared",
 );
+
+/**
+ * The path to the cloudflared binary.
+ * If the `CLOUDFLARED_BIN` environment variable is set, it will be used; otherwise, {@link DEFAULT_CLOUDFLARED_BIN} will be used.
+ * Can be overridden with {@link use}.
+ */
+export let bin = process.env.CLOUDFLARED_BIN || DEFAULT_CLOUDFLARED_BIN;
+
+/**
+ * Override the path to the cloudflared binary.
+ * @param executable - The path to the cloudflared executable.
+ */
+export function use(executable: string): void {
+    bin = executable;
+}
 
 export const CLOUDFLARED_VERSION = process.env.CLOUDFLARED_VERSION || "latest";
 


### PR DESCRIPTION
Make `bin` respect `process.env.CLOUDFLARED_BIN` before choosing the default path, and it can be changed later using `use`.