### PR TITLE
Don't use shell to start process

### DIFF
--- a/.changeset/five-chairs-study.md
+++ b/.changeset/five-chairs-study.md
@@ -1,0 +1,5 @@
+---
+"cloudflared": patch
+---
+
+Don't use shell to start process

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export async function main(): Promise<void> {
         console.log("Installed cloudflared to " + (await install(bin)));
     }
 
-    const sub = spawn(bin, args, { shell: true, stdio: "inherit" });
+    const sub = spawn(bin, args, { stdio: "inherit" });
 
     sub.on("exit", (code) => {
         if (typeof code === "number") {


### PR DESCRIPTION
This makes sure the executable name isn't parsed by the shell, avoiding errors when the executable path contains spaces or possibly other special characters.

Fixes #21 