### PR TITLE
Don't run binary on install

### DIFF
--- a/.changeset/pretty-knives-kick.md
+++ b/.changeset/pretty-knives-kick.md
@@ -1,0 +1,5 @@
+---
+"cloudflared": minor
+---
+
+Don't fail package installation if binary can't be run

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "docs": "typedoc ./src/lib.ts",
         "format": "prettier --write '**/*.{js,ts,jsx,tsx,json,yml,yaml,md,html}' --ignore-path .gitignore",
         "lint": "eslint .",
-        "postinstall": "node scripts/postinstall.mjs && node lib/cloudflared.js -v",
+        "postinstall": "node scripts/postinstall.mjs && node lib/cloudflared.js bin install latest",
         "changeset": "changeset"
     },
     "keywords": [


### PR DESCRIPTION
This PR changes the postinstall script to try installing the binary but not run it. In corporate environments where users have anti-virus-like software that stops arbitrary binaries from running, this lets the package be installed at all (as a dependency). Then the callers can prompt the user to either figure out how to run the binary and re-download it (using `install`) or proceed with reduced functionality.

Fixes #31.