### PR TITLE
fix: remove redundant error event listeners in Tunnel class

### DIFF
--- a/.changeset/pink-spoons-smash.md
+++ b/.changeset/pink-spoons-smash.md
@@ -1,0 +1,5 @@
+---
+"cloudflared": patch
+---
+
+Remove redundant error event listeners in Tunnel class

--- a/examples/tunnel.js
+++ b/examples/tunnel.js
@@ -1,9 +1,15 @@
-const { Tunnel } = require("cloudflared");
+const fs = require("node:fs");
+const { Tunnel, bin, install } = require("cloudflared");
 
 console.log("Cloudflared Tunnel Example.");
 main();
 
 async function main() {
+    if (!fs.existsSync(bin)) {
+        // install cloudflared binary
+        await install(bin);
+    }
+
     // run: cloudflared tunnel --hello-world
     const tunnel = Tunnel.quick();
 

--- a/examples/tunnel.mjs
+++ b/examples/tunnel.mjs
@@ -1,9 +1,15 @@
-import { Tunnel } from "cloudflared";
+import fs from "node:fs";
+import { Tunnel, bin, install } from "cloudflared";
 
 console.log("Cloudflared Tunnel Example.");
 main();
 
 async function main() {
+    if (!fs.existsSync(bin)) {
+        // install cloudflared binary
+        await install(bin)
+    }
+
     // run: cloudflared tunnel --hello-world
     const tunnel = Tunnel.quick();
 

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -76,14 +76,10 @@ export class Tunnel extends EventEmitter {
         // cloudflared outputs to stderr, but I think its better to listen to stdout too
         this.on("stdout", (output) => {
             this.processOutput(output);
-        }).on("error", (err) => {
-            this.emit("error", err);
         });
 
         this.on("stderr", (output) => {
             this.processOutput(output);
-        }).on("error", (err) => {
-            this.emit("error", err);
         });
     }
 


### PR DESCRIPTION
resolve #34 

This pull request simplifies error handling in the `Tunnel` class within `src/tunnel.ts` by removing redundant event listeners for the `error` event.

Key change:

* [`src/tunnel.ts`](diffhunk://#diff-53f4477ee3532f4249e378e0c1b112d2e58601aee3442dfd4f015c58b26785dcL79-L86): Removed `.on("error", ...)` listeners from both `stdout` and `stderr` event handlers in the `Tunnel` class, as they were redundant and the `error` event is already handled elsewhere.