### PR TITLE
ci: update test matrix versions for cloudflared

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,10 @@ jobs:
                     - macos-latest
                 version:
                     - "latest"
-                    - "2024.12.1"
-                    - "2024.10.1"
-                    - "2024.8.3"
-                    - "2024.6.1"
+                    - "2025.6.1"
+                    - "2025.4.2"
+                    - "2025.2.1"
+                    - "2024.12.2"
 
         name: "${{ matrix.os }} - ${{ matrix.version }}"
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This pull request updates the test matrix in the GitHub Actions workflow file `.github/workflows/test.yml`. The change involves replacing older versions with newer ones to ensure compatibility and coverage with the latest software releases.

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L23-R26): Updated the `jobs:` section to remove versions `2024.12.1`, `2024.10.1`, `2024.8.3`, and `2024.6.1`, and added versions `2025.6.1`, `2025.4.2`, `2025.2.1`, and `2024.12.2`.